### PR TITLE
(again) testing Cog labeled deploy for production

### DIFF
--- a/.github/workflows/cog-deploy.yml
+++ b/.github/workflows/cog-deploy.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - closed
 
 jobs:
   Deploy:
     name: Production Deploy of Cog
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && contains(github.event.label.name, 'deploy-cog')
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'deploy-cog')
     steps:
       - name: checkout repo
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
### How to deploy things with your PRs
By adding certain **labels** to your pull request (PR) into the `main` branch, you can trigger specific actions within the continuous integration and continuous deployment (CI/CD) process.

some available Labels
- `deploy-cog`: This label will trigger the "production deploy of cog" workflow, which will build and deploy the Cog project to production.
- `deploy-all`: This label will trigger the deployment of all projects in the CI/CD process.

### Activating a Workflow
To activate a workflow, you can either:
- cause a push event to the `main` branch
- use the "workflow-dispatch" event in the UI. To manually start a workflow, go to the "Actions" tab of your repository, find the workflow you'd like to run in the list of workflows, and click the "_Run workflow_" button.

For example, if you'd like to manually deploy Cog to production, you can go to the "Actions" tab, find the "production deploy of cog" workflow, and click the "Run workflow" button. You'll then be able to start the workflow by clicking "_Run workflow_".