### PR TITLE
spamcntrl-extension: changed link from purging.com to spamcntrl.com a…

### DIFF
--- a/apps/spamcntrl-extension/source/components/CFooter.tsx
+++ b/apps/spamcntrl-extension/source/components/CFooter.tsx
@@ -1,39 +1,43 @@
-import React from 'react'
-import { IUser } from '../models'
-import { getURL } from '../utils'
-import CIconButton from './CIconButton'
+import React from "react";
+import { IUser } from "../models";
+import { getURL, openLink } from "../utils";
+import CIconButton from "./CIconButton";
 
 interface CFooterProps {
-  user?: IUser | null
-  onClickLogout?: () => void
+  user?: IUser | null;
+  onClickLogout?: () => void;
 
-  activeNavBarKey?: string | null
+  activeNavBarKey?: string | null;
 }
 const defaultProps: CFooterProps = {
-  activeNavBarKey: 'home',
+  activeNavBarKey: "home",
   user: null,
-}
+};
 
 const CFooter: React.FC<CFooterProps> = ({}) => {
+  function onClickWebsiteLink() {
+    openLink("https://spamcntrl.com/", { active: true });
+  }
+
   return (
     <div className="fixed bottom-0 c-footer bg-alt w-full text-sm text-lnk flex justify-between items-center px-4 font-[450]">
-      <CIconButton icon={<span>purging.com</span>} />
+      <CIconButton icon={<span onClick={onClickWebsiteLink}>spamcntrl.com</span>} />
       <CIconButton
         icon={
           <span className="flex items-center h-full">
             <img
-              src={getURL('assets/icons/bug.svg')}
+              src={getURL("assets/icons/bug.svg")}
               style={{
-                marginRight: '3px',
+                marginRight: "3px",
               }}
-            />{' '}
-            <span style={{ lineHeight: '10px' }}>Report a Bug</span>
+            />{" "}
+            <span style={{ lineHeight: "10px" }}>Report a Bug</span>
           </span>
         }
       />
     </div>
-  )
-}
+  );
+};
 
-CFooter.defaultProps = defaultProps
-export default CFooter
+CFooter.defaultProps = defaultProps;
+export default CFooter;

--- a/apps/spamcntrl-extension/source/utils/index.ts
+++ b/apps/spamcntrl-extension/source/utils/index.ts
@@ -162,8 +162,8 @@ export function getLastNDigits(num: number | string, nDigits: number = 2) {
   return nString.substring(nString.length - nDigits);
 }
 
-export function openLink(url: string) {
-  return chrome.tabs.create({ url: url, active: false });
+export function openLink(url: string, opt?: object) {
+  return chrome.tabs.create({ url: url, active: false, ...opt });
 }
 
 export function hasYoutubeAuth(user: IUser) {


### PR DESCRIPTION
…nd open the link on new tab when clicked.

test:
1. `git fetch origin` and git checkout john/47-spamcntrl-extension-link-to-website-change-purgingcom-to-spamcntrlcom`
2. run `spamcntrl-extension` using `yarn dev:chrome`
3. the extension should be like this screenshot; https://prnt.sc/ZfQ-DKQL3mpn
4. when spamcntrl.com link is clicked should open new tab.